### PR TITLE
Full compatibility with Java 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Release notes
 =============
 
+1.10.0
+------
+
+*Released on 2024-07-31*
+
+* Require at least Java 8
+* Java 11 compatibility without any hidden dependencies
+* Removed depracated getters in `ClientImpl`
 
 1.9.1
 -----

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ tools and specifications [here][develhub].
 Installation and Documentation
 ------------------------------
 
-Requires **Java 7 SE**. Apart from that, and a tiny [SLF4J](http://slf4j.org/)
+Requires at least **Java 8 SE**. Apart from that, and a tiny [SLF4J](http://slf4j.org/)
 API library, *no other dependencies are required*. The resulting JAR is only
 `49kB` in size (as of version `1.8.0`).
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>eu.erasmuswithoutpaper</groupId>
     <artifactId>ewp-registry-client</artifactId>
-    <version>1.9.1</version>
+    <version>1.10.0</version>
     <packaging>jar</packaging>
 
     <name>EWP Registry Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
         <!-- Scope: TEST -->
 
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.6</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </distributionManagement>
 
     <properties>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/CatalogueDocument.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/CatalogueDocument.java
@@ -9,6 +9,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -20,7 +21,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.bind.DatatypeConverter;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.xpath.XPath;
@@ -399,7 +399,7 @@ class CatalogueDocument {
 
       for (Element keyElem : keyElems) {
         String fingerprint = keyElem.getAttribute("sha-256");
-        byte[] data = DatatypeConverter.parseBase64Binary(keyElem.getTextContent());
+        byte[] data = Base64.getMimeDecoder().decode(keyElem.getTextContent());
         X509EncodedKeySpec spec = new X509EncodedKeySpec(data);
         RSAPublicKey value;
         try {

--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/CatalogueDocument.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/CatalogueDocument.java
@@ -834,6 +834,8 @@ class CatalogueDocument {
   }
 
   static class CatalogueParserException extends RegistryClientException {
+    private static final long serialVersionUID = 8536812850006770409L;
+
     CatalogueParserException(String message) {
       super(message);
     }

--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/CatalogueFetcher.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/CatalogueFetcher.java
@@ -36,8 +36,8 @@ public interface CatalogueFetcher {
      * Thrown by {@link Http200RegistryResponse#deserialize(byte[])} when the raw data could not be
      * deserialized into a valid {@link Http200RegistryResponse} object.
      */
-    @SuppressWarnings("serial")
     static class CouldNotDeserialize extends Exception {
+      private static final long serialVersionUID = -3124583265761204268L;
     }
 
     /**

--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/ClientImplOptions.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/ClientImplOptions.java
@@ -37,15 +37,6 @@ public class ClientImplOptions {
   }
 
   /**
-   * @return Same as {@link #isAutoRefreshing()}.
-   * @deprecated As of release 1.2.0, replaced by {@link #isAutoRefreshing()}.
-   */
-  @Deprecated
-  public boolean getAutoRefreshing() { // NOPMD
-    return this.isAutoRefreshing();
-  }
-
-  /**
    * @return The {@link CatalogueFetcher} instance which will be used by the client. See
    *         {@link #setCatalogueFetcher(CatalogueFetcher)}.
    */
@@ -72,15 +63,6 @@ public class ClientImplOptions {
    * @since 1.4.0
    */
   public Map<String, byte[]> getPersistentCacheMap() {
-    return this.persistentCacheMap;
-  }
-
-  /**
-   * @return The cache instance to be used. See {@link #setPersistentCacheMap(Map)}.
-   * @deprecated As of release 1.4.0, replaced by {@link #getPersistentCacheMap()}.
-   */
-  @Deprecated
-  public Map<String, byte[]> getPersistentCacheProvider() {
     return this.persistentCacheMap;
   }
 

--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/RegistryClient.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/RegistryClient.java
@@ -28,8 +28,8 @@ public interface RegistryClient extends AutoCloseable {
    *
    * @since 1.0.0
    */
-  @SuppressWarnings("serial")
   class AssertionFailedException extends RegistryClientException {
+    private static final long serialVersionUID = 656646825926200510L;
 
     public AssertionFailedException(String message) {
       super(message);
@@ -44,8 +44,8 @@ public interface RegistryClient extends AutoCloseable {
    *
    * @since 1.4.0
    */
-  @SuppressWarnings("serial")
   class InvalidApiEntryElement extends RegistryClientRuntimeException {
+    private static final long serialVersionUID = 77972919923555248L;
 
     public InvalidApiEntryElement() {
       super();
@@ -103,8 +103,8 @@ public interface RegistryClient extends AutoCloseable {
    *
    * @since 1.0.0
    */
-  @SuppressWarnings("serial")
   abstract class RegistryClientRuntimeException extends RuntimeException {
+    private static final long serialVersionUID = -415231440678898545L;
 
     public RegistryClientRuntimeException() {
       super();
@@ -130,8 +130,8 @@ public interface RegistryClient extends AutoCloseable {
    *
    * @since 1.6.0
    */
-  @SuppressWarnings("serial")
   class StaleApiEntryElement extends InvalidApiEntryElement {
+    private static final long serialVersionUID = -3103542220915317349L;
 
     public StaleApiEntryElement() {
       super();
@@ -164,8 +164,8 @@ public interface RegistryClient extends AutoCloseable {
    *
    * @since 1.0.0
    */
-  @SuppressWarnings("serial")
   class UnacceptableStalenessException extends RegistryClientRuntimeException {
+    private static final long serialVersionUID = 4562127026735066789L;
   }
 
   /**

--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/Utils.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/Utils.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.RandomAccess;
 
-import javax.xml.bind.DatatypeConverter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -94,7 +93,7 @@ class Utils { // NOPMD
       throw new RuntimeException(e);
     }
     byte[] binDigest = md.digest();
-    return DatatypeConverter.printHexBinary(binDigest).toLowerCase(Locale.ENGLISH);
+    return printHexBinary(binDigest).toLowerCase(Locale.ENGLISH);
   }
 
   static String extractFingerprint(RSAPublicKey publicKey) {
@@ -106,7 +105,20 @@ class Utils { // NOPMD
     }
     md.update(publicKey.getEncoded());
     byte[] binDigest = md.digest();
-    return DatatypeConverter.printHexBinary(binDigest).toLowerCase(Locale.ENGLISH);
+    return printHexBinary(binDigest).toLowerCase(Locale.ENGLISH);
+  }
+
+  private static final char[] hexCode = "0123456789ABCDEF".toCharArray();
+
+  // javax.xml.bind.DatatypeConverter copy so that code can work with JDK >=11 without any
+  // additional jar (DatatypeConverter was removed in JDK 11 and Deprecated since JDK 9)
+  private static String printHexBinary(byte[] data) {
+    StringBuilder builder = new StringBuilder(data.length * 2);
+    for (byte b : data) {
+      builder.append(hexCode[(b >> 4) & 0xF]);
+      builder.append(hexCode[(b & 0xF)]);
+    }
+    return builder.toString();
   }
 
   /**


### PR DESCRIPTION
Real integration with JRE >= 11 requires adding `java.xml.bind` which is removed in JDK 11. I change code to JRE 8 equivalents. So it's work without any other libraries same on JRE 8 and JRE >= 11.