### PR TITLE
Remove unnecessary test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>4.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <!-- Since 1.6.X standard joox requires Java 11 -->
             <groupId>org.jooq</groupId>
             <artifactId>joox-java-6</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
             <version>4.4</version>

--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/ClientImplBasicTests.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/ClientImplBasicTests.java
@@ -14,13 +14,12 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import eu.erasmuswithoutpaper.registryclient.RegistryClient.AssertionFailedException;
 import eu.erasmuswithoutpaper.registryclient.RegistryClient.RefreshFailureException;
 import eu.erasmuswithoutpaper.registryclient.RegistryClient.UnacceptableStalenessException;
 
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 import org.assertj.core.util.Lists;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -568,12 +567,8 @@ public class ClientImplBasicTests extends TestBase {
     conds.setRequiredHei("bob.example.com");
     Collection<Element> apis = cli.findApis(conds);
     // There are two APIs matching these conditions. We want the 2.1.3 one (just for clarity).
-    CollectionUtils.filter(apis, new Predicate<Element>() {
-      @Override
-      public boolean evaluate(Element obj) {
-        return obj.getAttribute("version").equals("2.1.3");
-      }
-    });
+    apis = apis.stream().filter(obj -> obj.getAttribute("version").equals("2.1.3"))
+        .collect(Collectors.toList());
     assertThat(apis).hasSize(1);
     Element api1 = Lists.newArrayList(apis).get(0);
 

--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
@@ -3,9 +3,11 @@ package eu.erasmuswithoutpaper.registryclient;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
@@ -17,8 +19,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 
 import javax.xml.bind.DatatypeConverter;
-
-import org.apache.commons.io.IOUtils;
 
 /**
  * A common base for all other test classes. Provides some useful shortcut methods.
@@ -81,12 +81,12 @@ public class TestBase {
    * @param path as in {@link #getFile(String)}.
    * @throws IOException if the file does not exist.
    */
-  protected static byte[] getPossiblyNonExistingFile(String path) throws IOException {
-    InputStream stream = TestBase.class.getResourceAsStream("/test-files/" + path);
-    if (stream == null) {
+  protected static byte[] getPossiblyNonExistingFile(String relativePath) throws IOException {
+    Path path = Paths.get("src/test/resources/test-files/" + relativePath);
+    if (path.getFileName() == null) {
       throw new IOException("No such resource");
     }
-    return IOUtils.toByteArray(stream);
+    return String.join("\n", Files.readAllLines(path)).getBytes();
   }
 
   /**


### PR DESCRIPTION
Both dependencies (`commons-io` and `commons-collections4`) are old and totally unnecessary. Both can be replaced with less than 3 lines of code.