### PR TITLE
Remove remaining javax.xml.bind.DatatypeConverter usage from tests

### DIFF
--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
@@ -17,8 +17,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 /**
  * A common base for all other test classes. Provides some useful shortcut methods.
@@ -125,7 +124,7 @@ public class TestBase {
         }
       }
       br.close();
-      data = DatatypeConverter.parseBase64Binary(builder.toString());
+      data = Base64.getMimeDecoder().decode(builder.toString());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### Problem

`mvn test` fails during test compilation on any JDK >= 11:

```
[ERROR] TestBase.java:[21,22] package javax.xml.bind does not exist
[ERROR] TestBase.java:[128,14] cannot find symbol: variable DatatypeConverter
```

Because this happens in `testCompile`, the whole test suite is currently
impossible to run on a modern JDK.

### Cause

`javax.xml.bind` was removed from the JDK in Java 11. Commit dde5507
("Remove javax.xml.bind.DatatypeConverter usege for JDK >= 11 compatibility")
replaced the usages in `src/main`, but one usage was left in `src/test`.
`.travis.yml` still targets `oraclejdk8` / `openjdk7`, so CI would not have
caught it.

### Solution

Replace the remaining call with `java.util.Base64.getMimeDecoder()`.
`java.util.Base64` is available since Java 8, so the declared minimum Java
version is unchanged, and `getMimeDecoder()` matches `parseBase64Binary`'s
tolerance for characters outside the base64 alphabet.

### Testing

`mvn verify -Dgpg.skip=true` on JDK 21: Checkstyle passes and all 23 tests
pass. Before this change the build did not get past `testCompile`.

One note for transparency: on JDK 21 the build still fails later, in
`maven-javadoc-plugin:attach-javadocs`, due to pre-existing `<h3>` heading
ordering errors in the javadocs of `src/main`. That is unrelated to this
change and I left it alone; happy to open a separate PR for it if that would
be useful.
