### PR TITLE
Make the XXE test independent of the JVM's default locale

### DIFF
--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/GenericTests.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/GenericTests.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.fail;
 import eu.erasmuswithoutpaper.registryclient.RegistryClient.RefreshFailureException;
 
 import org.junit.Test;
+import org.xml.sax.SAXParseException;
 
 public class GenericTests extends TestBase {
 
@@ -39,7 +40,8 @@ public class GenericTests extends TestBase {
       cli.refresh();
       fail("Exception expected.");
     } catch (RefreshFailureException e) {
-      assertThat(e.getCause().getCause().getMessage()).contains("DOCTYPE is disallowed");
+      // The parser's message is localized, so we assert on the exception type instead.
+      assertThat(e.getCause().getCause()).isInstanceOf(SAXParseException.class);
     }
   }
 }

--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
@@ -17,8 +17,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 /**
  * A common base for all other test classes. Provides some useful shortcut methods.
@@ -125,7 +124,7 @@ public class TestBase {
         }
       }
       br.close();
-      data = DatatypeConverter.parseBase64Binary(builder.toString());
+      data = Base64.getMimeDecoder().decode(builder.toString());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### Problem

`GenericTests.testXXE` fails on any JVM whose default locale is not English,
because it asserts on the text of the parser's error message and Xerces
localizes that message. On a Spanish locale, for example:

```
Expecting actual:
  "DOCTYPE no esta permitido cuando la funcion "http://apache.org/xml/features/disallow-doctype-decl" se ha definido en true."
to contain:
  "DOCTYPE is disallowed"
```

The behaviour under test (rejecting a document with a DOCTYPE declaration) is
correct in both cases; only the assertion is locale-dependent.

### Solution

Assert on the exception type instead of the message text. `xxe.xml` is
otherwise a valid catalogue, so a `SAXParseException` here still means the
DOCTYPE was rejected, and the assertion no longer depends on the JVM's
default locale.

### Testing

`mvn verify -Dgpg.skip=true` on JDK 21 with a `es_ES` default locale:
Checkstyle passes and all 23 tests pass. Before the change, `testXXE` failed.

### Note

This branch is based on #26, because without that fix the test suite cannot be
compiled on JDK >= 11 and so this test cannot be run at all. If you prefer, I
can rebase it onto `master` once #26 is resolved, or squash the two together.
