### PR TITLE
Only send If-None-Match when an ETag is known

### DIFF
--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/DefaultCatalogueFetcher.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/DefaultCatalogueFetcher.java
@@ -71,7 +71,9 @@ public class DefaultCatalogueFetcher implements CatalogueFetcher {
     HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
     conn.setRequestMethod("GET");
     conn.setAllowUserInteraction(false);
-    conn.setRequestProperty("If-None-Match", previousETag);
+    if (previousETag != null) {
+      conn.setRequestProperty("If-None-Match", previousETag);
+    }
     conn.setConnectTimeout(10 * 1000); // 10 sec, establish a connection
     conn.setReadTimeout(60 * 1000); // 60 sec, read whole
     conn.connect();


### PR DESCRIPTION
### Problem

`CatalogueFetcher.fetchCatalogue` documents its `etag` argument as:

> If **null**, then this method will not use the `If-None-Match` header (and
> will therefore be expected to return an `Http200RegistryResponse`).

`DefaultCatalogueFetcher` sets the header unconditionally, so when no ETag is
known it calls `setRequestProperty("If-None-Match", null)`. That does not
throw, but the JDK still emits the header with an empty value. I confirmed
this against a local `HttpServer`: the request arrives with `If-None-Match`
present and its value empty.

An empty `If-None-Match` is not a valid conditional request header
(RFC 9110 §13.1.2 requires `*` or a list of entity-tags). In practice servers
ignore it and the Registry answers 200, so I have not seen this break
anything - it just does not match what the interface promises.

### Solution

Only set the header when an ETag is actually available.

### Testing

`mvn verify -Dgpg.skip=true` on JDK 21: Checkstyle passes and all 23 tests
pass.

I did not add a test for this. `DefaultCatalogueFetcher` builds an `https://`
URL itself, so covering it would mean standing up a TLS server in the test
suite, which seemed disproportionate for a two-line guard. Happy to add one
if you would prefer it.

Note: to run the test suite on JDK >= 11 at all, #26 is needed first.
