### PR TITLE
Do not re-read the persistent cache after checking it

### DIFF
--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/ClientImpl.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/ClientImpl.java
@@ -144,8 +144,7 @@ public class ClientImpl implements RegistryClient {
       byte[] data = cache.get(CATALOGUE_CACHE_KEY);
       if (data != null) {
         try {
-          Http200RegistryResponse cachedResponse =
-              Http200RegistryResponse.deserialize(cache.get(CATALOGUE_CACHE_KEY));
+          Http200RegistryResponse cachedResponse = Http200RegistryResponse.deserialize(data);
           this.doc = new CatalogueDocument(cachedResponse);
           logger.info("Loaded a catalogue from cache: {}", this.doc);
         } catch (CatalogueParserException | CouldNotDeserialize e) {

--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/ClientImplIntegrationTests.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/ClientImplIntegrationTests.java
@@ -17,6 +17,66 @@ import org.w3c.dom.Element;
 
 public class ClientImplIntegrationTests extends TestBase {
 
+  /**
+   * A cache which is purged right after its first successful read. This simulates the persistent
+   * cache being purged "without notice", which {@link ClientImplOptions#setPersistentCacheMap(Map)}
+   * explicitly allows.
+   */
+  private static class SelfPurgingCache extends HashMap<String, byte[]> {
+
+    private static final long serialVersionUID = 1L;
+
+    private boolean purged = false;
+
+    @Override
+    public byte[] get(Object key) {
+      if (this.purged) {
+        return null;
+      }
+      byte[] result = super.get(key);
+      if (result != null) {
+        this.purged = true;
+      }
+      return result;
+    }
+  }
+
+  @Test
+  public void testCachePurgedDuringConstruction() {
+
+    final CatalogueFetcher fetcher = new CatalogueFetcher() {
+
+      @Override
+      public RegistryResponse fetchCatalogue(String eTag) throws IOException {
+        byte[] content = TestBase.getFile("catalogue1.xml");
+        Date expires = new Date(new Date().getTime() + 300000);
+        return new Http200RegistryResponse(content, "catalogue1.xml", expires);
+      }
+    };
+
+    ClientImplOptions options = new ClientImplOptions();
+    options.setAutoRefreshing(true);
+    options.setCatalogueFetcher(fetcher);
+
+    // First, let a regular client fill the cache for us.
+
+    Map<String, byte[]> cache = new HashMap<>();
+    options.setPersistentCacheMap(cache);
+    try (RegistryClient cli = new ClientImpl(options)) {
+      assertThat(cli.findApis(new ApiSearchConditions())).hasSize(11);
+    }
+    assertThat(cache).isNotEmpty();
+
+    // Then hand the same contents to a client via a cache that is purged in the meantime.
+
+    SelfPurgingCache purgingCache = new SelfPurgingCache();
+    purgingCache.putAll(cache);
+    options.setPersistentCacheMap(purgingCache);
+    try (RegistryClient cli = new ClientImpl(options)) {
+      assertThat(cli.findApis(new ApiSearchConditions())).hasSize(11);
+    }
+  }
+
   @Test
   public void testPersistentCacheUsage() {
 

--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
@@ -17,8 +17,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 /**
  * A common base for all other test classes. Provides some useful shortcut methods.
@@ -125,7 +124,7 @@ public class TestBase {
         }
       }
       br.close();
-      data = DatatypeConverter.parseBase64Binary(builder.toString());
+      data = Base64.getMimeDecoder().decode(builder.toString());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### Problem

`new ClientImpl(options)` can fail with an unhandled `NullPointerException`
when a persistent cache is configured:

```
java.lang.NullPointerException: Cannot read the array length because "buf" is null
	at java.io.ByteArrayInputStream.<init>(ByteArrayInputStream.java:118)
	at ...CatalogueFetcher$Http200RegistryResponse.deserialize(CatalogueFetcher.java:49)
	at ...ClientImpl.<init>(ClientImpl.java:147)
```

`ClientImplOptions.setPersistentCacheMap` documents that

> It is okay for this cache to be purged without notice, it is also okay for
> some elements to be removed once other stay.

so this is a supported scenario, but it is not currently survivable.

### Cause

The constructor reads the cache key, null-checks the result, and then reads
the same key a **second** time and deserializes whatever comes back:

```java
byte[] data = cache.get(CATALOGUE_CACHE_KEY);
if (data != null) {
  try {
    Http200RegistryResponse cachedResponse =
        Http200RegistryResponse.deserialize(cache.get(CATALOGUE_CACHE_KEY));
```

If the cache is purged between the two reads, the second read returns `null`.
`deserialize(null)` throws `NullPointerException`, which is not one of the
caught exceptions (`CatalogueParserException | CouldNotDeserialize`), so it
propagates out of the constructor.

### Solution

Deserialize the value that was already read and null-checked.

### Testing

Added `ClientImplIntegrationTests.testCachePurgedDuringConstruction`, which
uses a cache that is purged right after its first successful read.

* Without the fix the test fails with the `NullPointerException` above.
* With the fix: `mvn verify -Dgpg.skip=true` on JDK 21, Checkstyle passes and
  all 24 tests pass.

Note: this branch is based on #26, since without it the test suite cannot be
compiled on JDK >= 11.
