### PR TITLE
Keep auto-refreshing after an unchecked exception

### DIFF
--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/ClientImpl.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/ClientImpl.java
@@ -227,6 +227,15 @@ public class ClientImpl implements RegistryClient {
                         + ClientImpl.this.options.getTimeBetweenRetries() + "ms.", e);
                 return new Date(
                     new Date().getTime() + ClientImpl.this.options.getTimeBetweenRetries());
+              } catch (RuntimeException e) {
+                /*
+                 * Letting this one through would kill the task, and no further refresh would ever
+                 * be scheduled.
+                 */
+                logger.error("Scheduled catalogue refresh failed unexpectedly. Will retry in "
+                    + ClientImpl.this.options.getTimeBetweenRetries() + "ms.", e);
+                return new Date(
+                    new Date().getTime() + ClientImpl.this.options.getTimeBetweenRetries());
               }
             }
 

--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/ClientImplIntegrationTests.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/ClientImplIntegrationTests.java
@@ -9,6 +9,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import eu.erasmuswithoutpaper.registryclient.RegistryClient.UnacceptableStalenessException;
 
@@ -16,6 +19,45 @@ import org.junit.Test;
 import org.w3c.dom.Element;
 
 public class ClientImplIntegrationTests extends TestBase {
+
+  /**
+   * A {@link CatalogueFetcher} is only expected to throw {@link IOException}, but a custom
+   * implementation may still fail in other ways. When it does, auto-refreshing should keep working.
+   */
+  @Test
+  public void testAutoRefreshingSurvivesUncheckedExceptions() throws InterruptedException {
+
+    final CountDownLatch fetchesAfterTheFailure = new CountDownLatch(1);
+    final AtomicInteger fetchCount = new AtomicInteger(0);
+
+    final CatalogueFetcher fetcher = new CatalogueFetcher() {
+
+      @Override
+      public RegistryResponse fetchCatalogue(String eTag) throws IOException {
+        int count = fetchCount.incrementAndGet();
+        if (count == 2) {
+          throw new IllegalStateException("Something unexpected in a custom fetcher.");
+        }
+        if (count > 2) {
+          fetchesAfterTheFailure.countDown();
+        }
+        byte[] content = TestBase.getFile("catalogue1.xml");
+        // Expire immediately, so that the client keeps refreshing.
+        return new Http200RegistryResponse(content, "catalogue" + count, new Date());
+      }
+    };
+
+    ClientImplOptions options = new ClientImplOptions();
+    options.setAutoRefreshing(true);
+    options.setCatalogueFetcher(fetcher);
+    options.setMinTimeBetweenQueries(100);
+    options.setTimeBetweenRetries(100);
+
+    try (RegistryClient cli = new ClientImpl(options)) {
+      assertThat(fetchesAfterTheFailure.await(10, TimeUnit.SECONDS))
+          .as("a refresh should still be scheduled after an unchecked exception").isTrue();
+    }
+  }
 
   @Test
   public void testPersistentCacheUsage() {

--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
@@ -17,8 +17,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 /**
  * A common base for all other test classes. Provides some useful shortcut methods.
@@ -125,7 +124,7 @@ public class TestBase {
         }
       }
       br.close();
-      data = DatatypeConverter.parseBase64Binary(builder.toString());
+      data = Base64.getMimeDecoder().decode(builder.toString());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### Problem

When auto-refreshing is enabled, a single unchecked exception during a
scheduled refresh permanently stops all further refreshes. The client then
keeps serving its stale copy of the catalogue, and once
`maxAcceptableStaleness` (5 days by default) is exceeded, every query starts
throwing `UnacceptableStalenessException`.

Measured with a fetcher that fails on its 2nd call and succeeds otherwise,
`minTimeBetweenQueries` and `timeBetweenRetries` both set to 200 ms, counting
fetches over 2.5 seconds:

| failure thrown on call #2 | fetches in 2.5 s |
| --- | --- |
| `IOException` | 13 (recovers) |
| `IllegalStateException` | 2 (never refreshes again) |

### Cause

The scheduled task only handles `RefreshFailureException`:

```java
} catch (RefreshFailureException e) {
  ...
  return new Date(now + timeBetweenRetries);
}
```

Anything else propagates out of `SelfSchedulableTask.run()` before it can
call `executor.schedule(this, ...)`, and `ScheduledExecutorService` discards
a task whose run threw, without logging anything.

This is reachable without a bug in the library: `refresh()` itself throws a
plain `RuntimeException` when a `CatalogueFetcher` returns an unsupported
`RegistryResponse` subclass, and both the fetcher and the persistent cache
map are supplied by the caller. `setPersistentCacheMap` suggests backing the
map by "a hard drive, or a similar medium", and such a map can fail at
runtime on `put()`.

### Solution

Also catch runtime exceptions in the scheduled task, log them, and schedule a
retry, the same way a `RefreshFailureException` is handled. I kept the change
inside `ClientImpl` rather than in `SelfSchedulableTask`, so the helper's
contract stays as it is, but I'm happy to move it if you would rather have
the guard in the base class.

### Testing

Added `ClientImplIntegrationTests.testAutoRefreshingSurvivesUncheckedExceptions`,
which waits (with a 10 s upper bound) for a refresh to happen after the
failing call, rather than asserting on timing.

* Without the fix the test fails: no further refresh is ever attempted.
* With the fix: `mvn verify -Dgpg.skip=true` on JDK 21, Checkstyle passes and
  all 24 tests pass.

Note: this branch is based on #26, since without it the test suite cannot be
compiled on JDK >= 11.
