### PR TITLE
Do not let an incomparable version shadow a higher one in findApi

### DIFF
--- a/src/main/java/eu/erasmuswithoutpaper/registryclient/CatalogueDocument.java
+++ b/src/main/java/eu/erasmuswithoutpaper/registryclient/CatalogueDocument.java
@@ -478,6 +478,16 @@ class CatalogueDocument {
     return true;
   }
 
+  /**
+   * Check if the given string is a version string this class is able to compare.
+   *
+   * @param version the string to check.
+   * @return <b>true</b> if it is a string of 3 non-negative integers separated by dots.
+   */
+  static boolean isComparableVersion(String version) {
+    return doesVersionXMatchMinimumRequiredVersionY(version, "0.0.0");
+  }
+
   public boolean isApiCoveredByServerKey(Element apiElement, RSAPublicKey serverKey)
       throws InvalidApiEntryElement {
     return this.extractFingerprintsForApiElement(apiElement)
@@ -573,7 +583,7 @@ class CatalogueDocument {
     for (Element entry : this.findApis(conditions)) {
       if (bestChoice == null) {
         bestChoice = entry;
-      } else if (bestChoice.getAttribute("version").length() == 0) {
+      } else if (!isComparableVersion(bestChoice.getAttribute("version"))) {
         bestChoice = entry;
       } else {
         String currentBest = bestChoice.getAttribute("version");

--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/ClientImplIntegrationTests.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/ClientImplIntegrationTests.java
@@ -17,6 +17,35 @@ import org.w3c.dom.Element;
 
 public class ClientImplIntegrationTests extends TestBase {
 
+  /**
+   * {@link RegistryClient#findApi(ApiSearchConditions)} promises to return the entry with the
+   * highest version. Entries whose version cannot be compared must not shadow the ones which can.
+   */
+  @Test
+  public void testFindApiWithNonSemanticVersion() {
+
+    final CatalogueFetcher fetcher = new CatalogueFetcher() {
+
+      @Override
+      public RegistryResponse fetchCatalogue(String eTag) throws IOException {
+        byte[] content = TestBase.getFile("catalogue-with-non-semantic-version.xml");
+        Date expires = new Date(new Date().getTime() + 300000);
+        return new Http200RegistryResponse(content, "catalogue3", expires);
+      }
+    };
+
+    ClientImplOptions options = new ClientImplOptions();
+    options.setAutoRefreshing(true);
+    options.setCatalogueFetcher(fetcher);
+
+    try (RegistryClient cli = new ClientImpl(options)) {
+      ApiSearchConditions conds = new ApiSearchConditions();
+      conds.setApiClassRequired("urn:test", "some-api");
+      assertThat(cli.findApis(conds)).hasSize(2);
+      assertThat(cli.findApi(conds).getAttribute("version")).isEqualTo("1.5.0");
+    }
+  }
+
   @Test
   public void testPersistentCacheUsage() {
 

--- a/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
+++ b/src/test/java/eu/erasmuswithoutpaper/registryclient/TestBase.java
@@ -17,8 +17,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 /**
  * A common base for all other test classes. Provides some useful shortcut methods.
@@ -125,7 +124,7 @@ public class TestBase {
         }
       }
       br.close();
-      data = DatatypeConverter.parseBase64Binary(builder.toString());
+      data = Base64.getMimeDecoder().decode(builder.toString());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/resources/test-files/catalogue-with-non-semantic-version.xml
+++ b/src/test/resources/test-files/catalogue-with-non-semantic-version.xml
@@ -1,0 +1,15 @@
+<catalogue
+    xmlns="https://github.com/erasmus-without-paper/ewp-specs-api-registry/tree/stable-v1"
+>
+    <!--
+        Two entries of the same API class. The first one does not use a semantic version
+        string, which is allowed: `apis-implemented` may reference *any* API, and those are
+        not required to inherit the `version` attribute of `ManifestApiEntryBase`.
+    -->
+    <host>
+        <apis-implemented>
+            <some-api xmlns="urn:test" version="2"/>
+            <some-api xmlns="urn:test" version="1.5.0"/>
+        </apis-implemented>
+    </host>
+</catalogue>


### PR DESCRIPTION
### Problem

`findApi` documents that

> If multiple matches are found, then this method will return the one that has
> the highest version attribute.

An entry whose `version` attribute is present but not in the `X.Y.Z` format
breaks that: once such an entry becomes the current best, nothing can replace
it, and `findApi` keeps returning it even when a higher, comparable version is
available.

Given two entries of the same API class:

```xml
<some-api xmlns="urn:test" version="2"/>
<some-api xmlns="urn:test" version="1.5.0"/>
```

`findApi` returns the `version="2"` entry.

### Cause

```java
} else if (bestChoice.getAttribute("version").length() == 0) {
  bestChoice = entry;
} else {
  ...
  if (doesVersionXMatchMinimumRequiredVersionY(newCandidate, currentBest)) {
    bestChoice = entry;
  }
}
```

`doesVersionXMatchMinimumRequiredVersionY` returns `false` whenever *either*
argument is not a valid `X.Y.Z` string. So when `currentBest` is incomparable,
every candidate compares `false` and the entry is never replaced. Only a
completely missing `version` attribute was handled, via the `length() == 0`
branch.

This is reachable from a valid catalogue: `common-types.xsd` constrains
`version` to `[0-9]+\.[0-9]+\.[0-9]+` only for entries extending
`ManifestApiEntryBase`, and notes that

> Clients MUST NOT assume that all children of `apis-implemented` will
> "inherit" these properties. (...) manifest files may contain references to
> *any* APIs.

`catalogue1.xml` in the test resources already carries such an entry
(`version="1.1.6seriously non-semantic"`).

### Solution

Treat an incomparable version the same way a missing one was already treated:
it may be replaced by a candidate. Added `isComparableVersion`, which reuses
the existing comparison logic rather than adding a second version parser.

Entries with well-formed versions keep behaving exactly as before, including
the existing `standalone3` case in `ClientImplBasicTests.testFindApi`, where an
entry with a version still wins over one without.

### Testing

Added `ClientImplIntegrationTests.testFindApiWithNonSemanticVersion` with a
small dedicated catalogue fixture, so no existing assertion is disturbed.

* Without the fix: `expected:<"[1.5.0]"> but was:<"[2]">`.
* With the fix: `mvn verify -Dgpg.skip=true` on JDK 21, Checkstyle passes and
  all 24 tests pass.

Note: this branch is based on #26, since without it the test suite cannot be
compiled on JDK >= 11.
